### PR TITLE
docs(deploy): make sure NPM_API_KEY is still defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/hoodiehq/pouchdb-hoodie-unsynced-local-docs.git"
   },
   "scripts": {
-    "deploydocs": "gh-pages-deploy",
+    "deploydocs": "NPM_API_KEY=foo gh-pages-deploy",
     "docs": "doxx --source ./lib --target docs/build --template docs/template.jade --ignore coverage,dist,helpers,node_modules,tests,utils,index.js",
     "test": "standard && npm run -s test:node | tap-spec",
     "test:coverage": "istanbul cover tests && istanbul-coveralls",


### PR DESCRIPTION
fixes https://github.com/hoodiehq/pouchdb-hoodie-unsynced-local-docs/issues/7
