### PR TITLE
Use pouchdb/extras/generateReplicationId

### DIFF
--- a/lib/unsynced-local-docs.js
+++ b/lib/unsynced-local-docs.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var genReplicationId = require('pouchdb/lib/replicate/gen-replication-id')
+var genReplicationId = require('pouchdb/extras/generateReplicationId')
 var toId = require('./utils/to-id')
 var toDoc = require('./utils/to-doc')
 


### PR DESCRIPTION
Ideally you shouldn't need to dig into PouchDB's internals to get a dependency; if there's ever something you need, we can expose it via the `extras` API or as a separate module. :)
